### PR TITLE
Fix skip-to-content link always visible — use screen-reader-only clip…

### DIFF
--- a/_sass/global.scss
+++ b/_sass/global.scss
@@ -993,17 +993,31 @@ hr {
 
 .skip-to-content {
 	position: absolute;
-	top: -100%;
-	left: 0;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
 	z-index: 10000;
-	padding: 12px 24px;
 	font-size: 1.6rem;
 	font-weight: 600;
 	color: #fff;
 	background: var(--jekyll-accent-color);
 	text-decoration: none;
 	&:focus {
+		position: fixed;
 		top: 0;
+		left: 0;
+		width: auto;
+		height: auto;
+		padding: 12px 24px;
+		margin: 0;
+		overflow: visible;
+		clip: auto;
+		white-space: normal;
 		outline: 3px solid var(--jekyll-accent-color);
 		outline-offset: 2px;
 	}


### PR DESCRIPTION
… pattern