### PR TITLE
Improve spacing and readability across the site

### DIFF
--- a/_sass/_article.scss
+++ b/_sass/_article.scss
@@ -59,22 +59,22 @@ except for when immediately preceeded by a heading */
 /* 6.4. Comments
 /* ---------------------------------------------------------- */
 .article {
-	padding: max(8px, 40px) 0 max(8px, 64px);
+	padding: max(12px, 56px) 0 max(12px, 80px);
 	word-break: break-word;
 }
 .page-template {
 	.article {
-		padding-top: max(1px, 64px);
+		padding-top: max(4px, 80px);
 	}
 	.article-header {
-		padding-bottom: max(3px, 28px);
+		padding-bottom: max(4px, 40px);
 	}
 	.article-title {
 		margin-bottom: 0;
 	}
 }
 .article-header {
-	padding: 0 0 max(7px, 40px) 0;
+	padding: 0 0 max(8px, 48px) 0;
 }
 .article-tag {
 	margin-bottom: 16px;
@@ -133,7 +133,7 @@ except for when immediately preceeded by a heading */
 		}
 	}
 	display: grid;
-	grid-template-columns: [full-start] minmax(max(4%, 20px), auto) [wide-start] minmax(auto, 240px) [main-start] min(720px, calc(100% - max(8%, 40px))) [main-end] minmax(auto, 240px) [wide-end] minmax(max(4%, 20px), auto) [full-end];
+	grid-template-columns: [full-start] minmax(max(5%, 24px), auto) [wide-start] minmax(auto, 240px) [main-start] min(740px, calc(100% - max(10%, 48px))) [main-end] minmax(auto, 240px) [wide-end] minmax(max(5%, 24px), auto) [full-end];
 	>* {
 		grid-column: main-start / main-end;
 	}
@@ -161,7 +161,7 @@ except for when immediately preceeded by a heading */
 	>* {
 		+ {
 			* {
-				margin-top: max(3px, 24px);
+				margin-top: max(4px, 32px);
 				margin-bottom: 0;
 			}
 		}
@@ -170,7 +170,7 @@ except for when immediately preceeded by a heading */
 		margin: 0;
 		color: $color_2;
 		&:not(:first-child) {
-			margin: 2em 0 0;
+			margin: 2.5em 0 0;
 		}
 		+ {
 			* {
@@ -180,19 +180,19 @@ except for when immediately preceeded by a heading */
 	}
 	>hr {
 		position: relative;
-		margin-top: max(5px, 32px);
+		margin-top: max(6px, 40px);
 		+ {
 			* {
-				margin-top: max(5px, 32px) !important;
+				margin-top: max(6px, 40px) !important;
 			}
 		}
 	}
 	>blockquote {
 		position: relative;
-		margin-top: max(5px, 32px);
+		margin-top: max(6px, 40px);
 		+ {
 			* {
-				margin-top: max(5px, 32px) !important;
+				margin-top: max(6px, 40px) !important;
 			}
 		}
 		&:not([class]) {
@@ -223,28 +223,28 @@ except for when immediately preceeded by a heading */
 		font-family: $font-family_1;
 		font-weight: 400;
 		font-size: 2rem;
-		line-height: 1.6em;
-		padding-left: 1.9em;
+		line-height: 1.7;
+		padding-left: 2em;
 	}
 	>ul {
 		font-family: $font-family_1;
 		font-weight: 400;
 		font-size: 2rem;
-		line-height: 1.6em;
-		padding-left: 1.9em;
+		line-height: 1.7;
+		padding-left: 2em;
 	}
 	>dl {
 		font-family: $font-family_1;
 		font-weight: 400;
 		font-size: 2rem;
-		line-height: 1.6em;
-		padding-left: 1.9em;
+		line-height: 1.7;
+		padding-left: 2em;
 	}
 	>p {
 		font-family: $font-family_1;
 		font-weight: 400;
 		font-size: 2rem;
-		line-height: 1.6em;
+		line-height: 1.7;
 	}
 	.kg-callout-card {
 		.kg-callout-text {

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -23,16 +23,13 @@ $border-top-color_1: color-mod(var(--color-darkmode) l(+8%));
 /* ---------------------------------------------------------- */
 .site-footer {
 	position: relative;
-	margin: max(12px, 64px) 0 0 0;
+	margin: max(16px, 80px) 0 0 0;
 	padding-top: 48px;
-	padding-bottom: 140px;
+	padding-bottom: 64px;
 	background: color-mod(var(--color-darkgrey) l(-5%));
 	text-align: center;
 	.inner {
-		// display: grid;
-		// grid-gap: 40px;
-		// grid-template-columns: auto 1fr auto;
-		font-size: 1.3rem;
+		font-size: 1.4rem;
 		text-align: center;
 	}
 	.copyright {

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -224,7 +224,7 @@ $background-color_6: var(--color-darkgrey);
 }
 .jekyll-head-inner {
 	display: grid;
-	column-gap: 40px;
+	column-gap: 24px;
 	grid-template-columns: auto 1fr auto;
 	grid-auto-flow: row dense;
 	align-items: center;
@@ -299,7 +299,7 @@ $background-color_6: var(--color-darkgrey);
 	align-items: center;
 	margin-top: 1px;
 	font-weight: 500;
-	margin-left: 250px;
+	margin-left: auto;
 	.nav {
 		display: inline-flex;
 		align-items: center;
@@ -509,7 +509,7 @@ $background-color_6: var(--color-darkgrey);
 	.is-head-left-logo {
 		.jekyll-head-menu {
 			margin-right: 0px;
-			margin-left: 250px;
+			margin-left: auto;
 		}
 	}
 	.is-head-middle-logo {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -18,6 +18,6 @@
 }
 .inner {
 	margin: 0 auto;
-	max-width: 720px;
+	max-width: 740px;
 	width: 100%;
 }

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -49,6 +49,8 @@ make sure this only happens on large viewports / desktop-ish devices.
 	flex-direction: column;
 	background-size: cover;
 	word-break: break-word;
+	padding-bottom: 24px;
+	margin-bottom: 8px;
 	&:not(.post-card-large) {
 		&:not(.post-card-full) {
 			&:not(.dynamic) {

--- a/_sass/_utils.scss
+++ b/_sass/_utils.scss
@@ -1,14 +1,12 @@
 .hero {
-
+    margin-bottom: 48px;
 }
 
-
-
-.section  {
+.section {
+    margin-top: 48px;
 
     .section-title {
-        margin: 0;
-        margin-top: 0px;
+        margin: 0 0 24px 0;
         font-size: 2.6rem;
         font-weight: 800;
         line-height: 1.2;

--- a/_sass/global.scss
+++ b/_sass/global.scss
@@ -49,7 +49,7 @@ body {
 	color: $color_2;
 	font-family: $font-family_4;
 	font-size: 1.6rem;
-	line-height: 1.6em;
+	line-height: 1.7;
 	font-weight: 400;
 	font-style: normal;
 	letter-spacing: 0;

--- a/contact.md
+++ b/contact.md
@@ -15,7 +15,7 @@ If you have an ambitious project in mind and a reasonable budget, I'd love to di
 
 ## Book an appointment
 
-- [Schedule a Call](https://calendly.com/yoosuf/talk-with-yoosuf)
+- [Schedule a Call](https://cal.com/yoosuf/30min?user=yoosuf)
 - [E-mail Me](mailto:mayoosuf@gmail.com)
 - [Reach me on Twitter](https://twitter.com/aitchdei)
 - [Reach me on LinkedIn](https://linkedin.com/in/yoosufmo)


### PR DESCRIPTION
- Increase body line-height from 1.6em to 1.7 for better readability
- Widen content column from 720px to 740px with larger gutters
- Increase vertical rhythm between content blocks (24px -> 32px)
- Add more space above headings (2em -> 2.5em)
- Add padding/margin between blog post cards
- Reduce footer padding from 140px to 64px
- Increase hero/section spacing on homepage
- Use auto margin for nav instead of fixed 250px offset
- Tighter header column gap (40px -> 24px)