### PR TITLE
Add breadcrumbs for posts and pages

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,0 +1,55 @@
+{% comment %}
+  Renders a visible breadcrumb trail plus a matching BreadcrumbList JSON-LD block.
+  Expects `page` in scope. Trail is: Home > [Blog >] Current.
+{% endcomment %}
+{%- assign crumbs = "" | split: "" -%}
+{%- assign home_crumb = "Home|" | append: site.url | append: "/" -%}
+{%- assign crumbs = crumbs | push: home_crumb -%}
+
+{%- if page.collection == "posts" -%}
+  {%- assign blog_crumb = "Blog|" | append: site.url | append: "/blog/" -%}
+  {%- assign crumbs = crumbs | push: blog_crumb -%}
+  {%- assign crumbs = crumbs | push: page.title -%}
+{%- elsif page.url == "/blog/" -%}
+  {%- assign current_title = page.title | default: "Blog" -%}
+  {%- assign crumbs = crumbs | push: current_title -%}
+{%- else -%}
+  {%- assign crumbs = crumbs | push: page.title -%}
+{%- endif -%}
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <ol class="breadcrumb-list">
+    {%- for crumb in crumbs -%}
+    {%- assign parts = crumb | split: "|" -%}
+    {%- assign label = parts[0] -%}
+    {%- assign crumb_url = parts[1] -%}
+    <li class="breadcrumb-item">
+      {%- if crumb_url -%}
+      <a href="{{ crumb_url }}">{{ label }}</a>
+      {%- else -%}
+      <span aria-current="page">{{ label }}</span>
+      {%- endif %}
+    </li>
+    {%- endfor %}
+  </ol>
+</nav>
+
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {%- for crumb in crumbs -%}
+      {%- assign parts = crumb | split: "|" -%}
+      {%- assign label = parts[0] -%}
+      {%- assign crumb_url = parts[1] -%}
+      {
+        "@type": "ListItem",
+        "position": {{ forloop.index }},
+        "name": {{ label | jsonify }}{% if crumb_url %},
+        "item": {{ crumb_url | jsonify }}{% endif %}
+      }{% unless forloop.last %},{% endunless %}
+      {%- endfor %}
+    ]
+  }
+</script>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -4,6 +4,7 @@ layout: default
 
 <div class="site-main">
   <article class="article">
+    {% include breadcrumbs.html %}
     {% if page.title %}
     <header class="article-header jekyll-canvas">
       <h1 class="article-title">{{ page.title | default: "Blog" | escape }}</h1>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,6 +3,7 @@ layout: default
 ---
 
 <article class="article">
+  {% include breadcrumbs.html %}
   {% if page.title %}
   <header class="article-header jekyll-canvas">
     <h1 class="article-title">{{ page.title | escape }}</h1>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,6 +3,7 @@ layout: default
 ---
 
 <article class="article post">
+  {% include breadcrumbs.html %}
   <header class="article-header jekyll-canvas">
     {% if page.categories.size > 0 %}
     <ul class="chip-list" aria-label="Categories">

--- a/_sass/_article.scss
+++ b/_sass/_article.scss
@@ -2,6 +2,41 @@
 	padding: max(12px, 56px) 0 max(12px, 80px);
 	word-break: break-word;
 }
+.breadcrumbs {
+	margin: 0 0 16px;
+}
+.breadcrumb-list {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 6px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	font-size: 1.3rem;
+	color: var(--color-secondary-text);
+}
+.breadcrumb-item {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	a {
+		color: var(--color-secondary-text);
+		text-decoration: none;
+		&:hover {
+			color: var(--jekyll-accent-color);
+			text-decoration: underline;
+		}
+	}
+	&:not(:last-child)::after {
+		content: "/";
+		margin-left: 6px;
+		color: var(--color-border);
+	}
+	&:last-child span {
+		color: var(--color-midgrey);
+	}
+}
 .page-template {
 	.article {
 		padding-top: max(4px, 80px);


### PR DESCRIPTION
## Summary
- Adds `_includes/breadcrumbs.html`, a shared include rendering both a visible breadcrumb nav and a matching `BreadcrumbList` JSON-LD block
- Wired into post, page, and blog-index layouts: `Home > Blog > Post Title` for posts, `Home > Page Title` for static pages, `Home > Blog` for the blog index
- Home page intentionally excluded (it's already the root)
- Added `.breadcrumbs`/`.breadcrumb-list`/`.breadcrumb-item` styles matching existing design tokens

## Test plan
- [x] `bundle exec jekyll build` succeeds with no errors
- [x] Verified rendered breadcrumb + JSON-LD on a post, About, Contact, Blog index, and 404 pages
- [x] Confirmed JSON-LD parses as valid JSON for a title containing an HTML entity
- [x] Confirmed home page has no breadcrumb