### PR TITLE
Constrain breadcrumbs to the site content width

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -4,7 +4,9 @@ layout: default
 
 <div class="site-main">
   <article class="article">
-    {% include breadcrumbs.html %}
+    <div class="jekyll-canvas">
+      {% include breadcrumbs.html %}
+    </div>
     {% if page.title %}
     <header class="article-header jekyll-canvas">
       <h1 class="article-title">{{ page.title | default: "Blog" | escape }}</h1>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,9 @@ layout: default
 ---
 
 <article class="article">
-  {% include breadcrumbs.html %}
+  <div class="jekyll-canvas">
+    {% include breadcrumbs.html %}
+  </div>
   {% if page.title %}
   <header class="article-header jekyll-canvas">
     <h1 class="article-title">{{ page.title | escape }}</h1>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,8 +3,8 @@ layout: default
 ---
 
 <article class="article post">
-  {% include breadcrumbs.html %}
   <header class="article-header jekyll-canvas">
+    {% include breadcrumbs.html %}
     {% if page.categories.size > 0 %}
     <ul class="chip-list" aria-label="Categories">
       {% for category in page.categories %}


### PR DESCRIPTION
Breadcrumbs were direct children of .article, which has no width constraint of its own — the max-width comes from the jekyll-canvas grid class used by the header/content sections. Nesting breadcrumbs inside that grid keeps them aligned with the rest of the content column instead of spanning the full container.