### PR TITLE
Fix inconsistent social and repo links

### DIFF
--- a/_posts/2023-06-01-how-i-do-water-fasting.md
+++ b/_posts/2023-06-01-how-i-do-water-fasting.md
@@ -40,4 +40,4 @@ I avoid drinking any liquids that contain calories, sugar, or artificial sweeten
 
 If you are considering water fasting, it is important to choose liquids that are safe and healthy. Water, unsweetened tea, and unsweetened coffee are all good choices.
 
-I hope you found this article interesting. If you have any questions or comments, please feel free to contact me. And if you found this article helpful, please consider subscribing to [my YouTube channel](https://www.youtube.com/@yoosufmo) for more fitness and health related video content.
+I hope you found this article interesting. If you have any questions or comments, please feel free to contact me. And if you found this article helpful, please consider subscribing to [my YouTube channel](https://www.youtube.com/@YoosufMo) for more fitness and health related video content.

--- a/_sass/screen.scss
+++ b/_sass/screen.scss
@@ -17,7 +17,7 @@ Hey! You reached the end.
 Hope you enjoyed this CSS file, if you have any suggestions
 for improvements that might be useful for everyone who uses
 this theme, you can find the open source repository for it
-here: https://github.com/yoosuf/yoosuf
+here: https://github.com/yoosuf/yoosuf.github.io
 
 Or, if you've just scrolled all the way to the bottom of the
 file to add some of your own styles. Well, you've come to

--- a/llms.txt
+++ b/llms.txt
@@ -57,7 +57,7 @@
 ## Social Profiles
 
 - GitHub: https://github.com/yoosuf
-- LinkedIn: https://www.linkedin.com/in/yoosufmo
+- LinkedIn: https://www.linkedin.com/in/yoosufm
 - Twitter/X: https://twitter.com/aitchdei
 - Instagram: https://www.instagram.com/aitchdei
 - YouTube: https://www.youtube.com/@YoosufMo


### PR DESCRIPTION
## Summary
- `llms.txt` listed the LinkedIn handle as `yoosufmo`, while `_config.yml`, `_layouts/default.html`, and `_data/authors.yml` all use `yoosufm`. Confirmed `linkedin.com/in/yoosufmo` 301-redirects to `linkedin.com/in/yoosufm`, so standardized on the canonical `yoosufm`.
- `_sass/screen.scss` had an easter-egg comment pointing to `github.com/yoosuf/yoosuf`, which doesn't exist. Fixed to the actual repo, `github.com/yoosuf/yoosuf.github.io`.
- Standardized YouTube handle casing in one 2023 post (`@yoosufmo` → `@YoosufMo`) to match the casing used everywhere else on the site.

Left the 2013-era posts referencing the old `@eyoosuf` Twitter handle and `jsfiddle.net/eyoosuf` embeds untouched — they document the author's identity at the time of writing, and changing them would misstate the historical narrative (and break the jsfiddle embeds, which are saved under that old username).

## Test plan
- [x] Verified `linkedin.com/in/yoosufmo` redirects to `linkedin.com/in/yoosufm` via direct fetch
- [x] Verified `github.com/yoosuf` resolves to the correct live profile
- [x] `bundle exec jekyll build` completes with no new errors or warnings introduced
- [x] Grepped the full repo to confirm all Twitter/X, GitHub, LinkedIn, Instagram, Facebook, and YouTube references are now consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)